### PR TITLE
Add WattsonBot (Tesla alerts in Telegram)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Want to contribute? Fork this repository, add your resources and send us a PR.
  - [TeslaFi](www.teslafi.com) - Incredible wealth of stats for your Tesla.
  - [Teslastics](https://teslastics.com) - Teslastics is a platform to monitorize your Tesla.
  - [Teslamate](https://github.com/adriankumpf/teslamate) - A self-hosted data logger for your Tesla
+ - [WattsonBot](https://wattsonbot.org) - Real-time Tesla alerts and stats in Telegram - charging, battery, TPMS and drive summaries
 
 ## News
 


### PR DESCRIPTION
Adds [WattsonBot](https://wattsonbot.org) to Web Statistics — a Telegram bot that delivers real-time Tesla alerts (charging, battery, TPMS) and drive summaries with on-demand stats. Placed next to Teslamate since it's built on similar data.

Disclosure: I'm the author of the project.