### PR TITLE
Add Tesla Chargers to In-Car Browser Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Want to contribute? Fork this repository, add your resources and send us a PR.
  - [Tesla Winds and Elevation](https://teslawinds.com/) - Show your course, ground speed, wind direction, crosswind, headwind/tailwind, elevation, climb/descend rates and grade.
  - [qTesla](https://qtes.la/) - Tesla browser based app launcher
  - [Kinetic Tesla Screens](http://www.kinetic.com/teslascreens/) - Cool screens for Tesla browser such as Kitt & The Matrix and more.
+ - [Tesla Chargers](https://tesla-chargers.com) - Find nearby Superchargers with stall counts, peak charging speeds, amenities and directions.
 
 
 ## Web Apps


### PR DESCRIPTION
Adds [Tesla Chargers](https://tesla-chargers.com) — a free Supercharger finder covering ~8,800 sites worldwide: search by location or city, stall counts, peak charging speeds, connector types, amenities, favorites, and one-tap directions. No ads, no account needed, and it works in the car's browser. Data from the supercharge.info community dataset.